### PR TITLE
Make invalid subpalettes visible to the user

### DIFF
--- a/src/tileeditor/arrangement_editor.py
+++ b/src/tileeditor/arrangement_editor.py
@@ -85,5 +85,8 @@ class TileArrangementWidget(TileGraphicsWidget):
         
         if not nosubpal:
             subpalette = self.currentTile.getMinitileSubpalette(index)
+            if subpalette < 0:
+                # The tile has an invalid subpalette. For "pick" purposes, fall back to subpalette 0.
+                subpalette = 0
             self.state.tileEditor.paletteView.setSubpaletteIndex(subpalette)
             self.state.tileEditor.onSubpaletteSelect()


### PR DESCRIPTION
This will prevent issues such as those seen in the EBBR project, where it's unclear that certain tiles will not show as expected in-game.