### PR TITLE
Combined cache + Map palette preview

### DIFF
--- a/src/actions/fts_actions.py
+++ b/src/actions/fts_actions.py
@@ -290,9 +290,9 @@ class ActionAddPalette(QUndoCommand):
         for key, t in self.projectData.tilegfx.items():
             t[common.combinePaletteAndGroup(self.palette.groupID, self.palette.paletteID)] = {}
         
-            for i in range(common.MAXTILES):
-                graphic = MapTileGraphic(i, key, self.palette.groupID, self.palette.paletteID)
-                t[common.combinePaletteAndGroup(self.palette.groupID, self.palette.paletteID)][i] = graphic
+            # for i in range(common.MAXTILES):
+            #     graphic = MapTileGraphic(i, key, self.palette.groupID, self.palette.paletteID)
+            #     t[common.combinePaletteAndGroup(self.palette.groupID, self.palette.paletteID)][i] = graphic
     
     def undo(self):   
         tileset = self.projectData.getTilesetFromPaletteGroup(self.palette.groupID)

--- a/src/actions/fts_actions.py
+++ b/src/actions/fts_actions.py
@@ -287,10 +287,12 @@ class ActionAddPalette(QUndoCommand):
         settings = PaletteSettings(0, 0, 0)
         self.projectData.paletteSettings[self.palette.groupID][self.palette.paletteID] = settings
         
-        newGraphics = self.projectData.tilegfx[tileset.id][self.palette.groupID][self.palette.paletteID] = {}
-        for i in range(common.MAXTILES):
-            graphic = MapTileGraphic(i, tileset.id, self.palette.groupID, self.palette.paletteID)
-            newGraphics[i] = graphic
+        for key, t in self.projectData.tilegfx.items():
+            t[common.combinePaletteAndGroup(self.palette.groupID, self.palette.paletteID)] = {}
+        
+            for i in range(common.MAXTILES):
+                graphic = MapTileGraphic(i, key, self.palette.groupID, self.palette.paletteID)
+                t[common.combinePaletteAndGroup(self.palette.groupID, self.palette.paletteID)][i] = graphic
     
     def undo(self):   
         tileset = self.projectData.getTilesetFromPaletteGroup(self.palette.groupID)
@@ -299,7 +301,11 @@ class ActionAddPalette(QUndoCommand):
         
         self.projectData.paletteSettings[self.palette.groupID].pop(self.palette.paletteID, None)
         
-        self.projectData.tilegfx[tileset.id][self.palette.groupID].pop(self.palette.paletteID, None) 
+        for t in self.projectData.tilegfx.values():
+            keys = list(t.keys())
+            for key in keys:
+                if key == common.combinePaletteAndGroup(self.palette.groupID, self.palette.paletteID):
+                    t.pop(key, None)
                    
     def mergeWith(self, other):
         return False

--- a/src/coilsnake/datamodules/tile_graphics.py
+++ b/src/coilsnake/datamodules/tile_graphics.py
@@ -9,14 +9,19 @@ class TileGraphicsModule(DataModule):
     
     def load(data: ProjectData):
         tilegfx = {}
+        
+        keys = []
+        for t in data.tilesets:
+            for g in t.paletteGroups:
+                for p in g.palettes:
+                    keys.append(common.combinePaletteAndGroup(g.groupID, p.paletteID))
+        
         for t in data.tilesets:
             tilegfx[t.id] = {}
-            for g in t.paletteGroups:
-                tilegfx[t.id][g.groupID] = {}
-                for p in g.palettes:
-                    tilegfx[t.id][g.groupID][p.paletteID] = {}
-                    for mt in range(common.MAXTILES):
-                        tilegfx[t.id][g.groupID][p.paletteID][mt] = MapTileGraphic(mt, t.id, g.groupID, p.paletteID)
+            for pg in keys:
+                tilegfx[t.id][pg] = {}
+                for mt in range(common.MAXTILES):
+                    tilegfx[t.id][pg][mt] = MapTileGraphic(mt, t.id, *common.extractPaletteAndGroup(pg))
 
         data.tilegfx = tilegfx
     

--- a/src/coilsnake/datamodules/tile_graphics.py
+++ b/src/coilsnake/datamodules/tile_graphics.py
@@ -20,8 +20,8 @@ class TileGraphicsModule(DataModule):
             tilegfx[t.id] = {}
             for pg in keys:
                 tilegfx[t.id][pg] = {}
-                for mt in range(common.MAXTILES):
-                    tilegfx[t.id][pg][mt] = MapTileGraphic(mt, t.id, *common.extractPaletteAndGroup(pg))
+                # for mt in range(common.MAXTILES):
+                #     tilegfx[t.id][pg][mt] = MapTileGraphic(mt, t.id, *common.extractPaletteAndGroup(pg))
 
         data.tilegfx = tilegfx
     

--- a/src/coilsnake/project_data.py
+++ b/src/coilsnake/project_data.py
@@ -116,11 +116,11 @@ class ProjectData():
                         self.tilegfx[tileset][
                             common.combinePaletteAndGroup(paletteGroup, p.paletteID)] = {}
             else: # clear one tileset
-                for pg in self.tilegfx[tileset].values():
+                for pg in self.tilegfx[tileset].keys():
                     self.tilegfx[tileset][pg] = {}
         else: # clear entire cache
             for t in self.tilegfx.values():
-                for pg in t.values():
+                for pg in t.keys():
                     t[pg] = {}
                             
     # project getters

--- a/src/coilsnake/project_data.py
+++ b/src/coilsnake/project_data.py
@@ -31,7 +31,7 @@ class ProjectData():
         self.paletteSettings: dict[int, dict[int, PaletteSettings]] = {}
         self.sectors: numpy.ndarray[Sector] = []
         self.tiles: numpy.ndarray[MapTile] = []
-        self.tilegfx: dict[int, dict[int, dict[int, dict[int, MapTileGraphic]]]] = {}
+        self.tilegfx: dict[int, dict[str, dict[int, MapTileGraphic]]] = {}
         self.npcs: list[NPC] = []
         self.npcinstances: list[NPCInstance] = []
         self.sprites: list[Sprite] = []
@@ -97,28 +97,6 @@ class ProjectData():
         self.tilesets[tilesetNumber] = newTileset
     
         self.clobberTileGraphicsCache(tilesetNumber)
-
-    def resolveTileGraphic(self, tileset: int, palettegroup: int, palette: int, tile: int) -> MapTileGraphic:
-        """Find the closest valid tile graphic if the requested one is invalid."""
-        tile = common.cap(tile, 0, common.MAXTILES)
-
-        for i in self.tilegfx.items():
-            if i[0] == tileset:
-                break
-            else:
-                tileset = i[0]
-        for i in self.tilegfx[tileset].items():
-            if i[0] == palettegroup:
-                break
-            else:
-                palettegroup = i[0]
-        for i in self.tilegfx[tileset][palettegroup].items():
-            if i[0] == palette:
-                break
-            else:
-                palette = i[0]
-                
-        return self.tilegfx[tileset][palettegroup][palette][tile]
     
     def clobberTileGraphicsCache(self, tileset: int|None=None, paletteGroup: int|None=None, palette: int|None=None, tile: int|None=None):
         """Clear cached tile graphics. Failing to specify an argument clears all graphics under that argument."""
@@ -130,27 +108,28 @@ class ProjectData():
                         gfx.hasRendered = False
                         gfx.hasRenderedFg = False
                     else: # clear one palette
-                        for gfx in self.tilegfx[tileset][paletteGroup][palette].values():
+                        for gfx in self.tilegfx[tileset][
+                            common.combinePaletteAndGroup(paletteGroup, palette)].values():
                             gfx.hasRendered = False
                             gfx.hasRenderedFg = False
                 else: # clear one palette group
-                    for p in self.tilegfx[tileset][paletteGroup].values():
-                        for gfx in p.values():
+                    group = self.getPaletteGroup(paletteGroup)
+                    for p in group.palettes:
+                        for gfx in self.tilegfx[tileset][
+                            common.combinePaletteAndGroup(paletteGroup, p.paletteID)].values():
                             gfx.hasRendered = False
                             gfx.hasRenderedFg = False
             else: # clear one tileset
                 for pg in self.tilegfx[tileset].values():
-                    for p in pg.values():
-                        for gfx in p.values():
-                            gfx.hasRendered = False
-                            gfx.hasRenderedFg = False
+                    for gfx in pg.values():
+                        gfx.hasRendered = False
+                        gfx.hasRenderedFg = False
         else: # clear entire cache
             for t in self.tilegfx.values():
                 for pg in t.values():
-                    for p in pg.values():
-                        for gfx in p.values():
-                            gfx.hasRendered = False
-                            gfx.hasRenderedFg = False
+                    for gfx in pg.values():
+                        gfx.hasRendered = False
+                        gfx.hasRenderedFg = False
                             
     # project getters
     def getProjectVersion(self) -> str:
@@ -293,7 +272,7 @@ class ProjectData():
                        palettegroup: int, 
                        palette: int, 
                        tile: int) -> MapTileGraphic:
-        return self.tilegfx[tileset][palettegroup][palette][tile]
+        return self.tilegfx[tileset][common.combinePaletteAndGroup(palettegroup, palette)][tile]
                     
     def getNPC(self, id: int) -> NPC:
         return self.npcs[id]

--- a/src/coilsnake/project_data.py
+++ b/src/coilsnake/project_data.py
@@ -108,28 +108,20 @@ class ProjectData():
                         gfx.hasRendered = False
                         gfx.hasRenderedFg = False
                     else: # clear one palette
-                        for gfx in self.tilegfx[tileset][
-                            common.combinePaletteAndGroup(paletteGroup, palette)].values():
-                            gfx.hasRendered = False
-                            gfx.hasRenderedFg = False
+                        self.tilegfx[tileset][
+                            common.combinePaletteAndGroup(paletteGroup, palette)] = {}
                 else: # clear one palette group
                     group = self.getPaletteGroup(paletteGroup)
                     for p in group.palettes:
-                        for gfx in self.tilegfx[tileset][
-                            common.combinePaletteAndGroup(paletteGroup, p.paletteID)].values():
-                            gfx.hasRendered = False
-                            gfx.hasRenderedFg = False
+                        self.tilegfx[tileset][
+                            common.combinePaletteAndGroup(paletteGroup, p.paletteID)] = {}
             else: # clear one tileset
                 for pg in self.tilegfx[tileset].values():
-                    for gfx in pg.values():
-                        gfx.hasRendered = False
-                        gfx.hasRenderedFg = False
+                    self.tilegfx[tileset][pg] = {}
         else: # clear entire cache
             for t in self.tilegfx.values():
                 for pg in t.values():
-                    for gfx in pg.values():
-                        gfx.hasRendered = False
-                        gfx.hasRenderedFg = False
+                    t[pg] = {}
                             
     # project getters
     def getProjectVersion(self) -> str:
@@ -272,7 +264,9 @@ class ProjectData():
                        palettegroup: int, 
                        palette: int, 
                        tile: int) -> MapTileGraphic:
-        return self.tilegfx[tileset][common.combinePaletteAndGroup(palettegroup, palette)][tile]
+        return self.tilegfx[tileset][common.combinePaletteAndGroup(palettegroup, palette)].setdefault(
+            tile, MapTileGraphic(tile, tileset, palettegroup, palette)
+        )
                     
     def getNPC(self, id: int) -> NPC:
         return self.npcs[id]

--- a/src/mapeditor/map/map_scene.py
+++ b/src/mapeditor/map/map_scene.py
@@ -889,7 +889,8 @@ class MapEditorScene(QGraphicsScene):
             tileGraphic = self.projectData.getTileGraphic(tilesetID, paletteGroupID, paletteID, toPlace)
 
             if not tileGraphic.hasRendered:
-                tileGraphic.render(self.projectData.getTileset(tilesetID))
+                palette = self.projectData.getPaletteGroup(paletteGroupID).palettes[paletteID]
+                tileGraphic.render(self.projectData.getTileset(tilesetID), palette)
 
             # item.setPixmap(tileGraphic.rendered)
             # item.setText(str(toPlace).zfill(3))
@@ -948,7 +949,8 @@ class MapEditorScene(QGraphicsScene):
         except KeyError as e:
             raise KeyError(f"No such tile with tileset {tile.tileset}, palette group {tile.palettegroup}, palette {tile.palette}, tile {tile.tile}.") from e
         if not tileGraphic.hasRendered:
-            tileGraphic.render(self.projectData.getTileset(tile.tileset))
+            palette = self.projectData.getPaletteGroup(tile.palettegroup).palettes[tile.palette]
+            tileGraphic.render(self.projectData.getTileset(tile.tileset), palette)
         
         self.update(*tile.coords.coords(), 32, 32)
             
@@ -1510,7 +1512,8 @@ class MapEditorScene(QGraphicsScene):
                                                             tile.palette,
                                                             tile.tile)
                     if not graphic.hasRendered:
-                        graphic.render(self.projectData.getTileset(tile.tileset))
+                        palette = self.projectData.getPaletteGroup(tile.palettegroup).palettes[tile.palette]
+                        graphic.render(self.projectData.getTileset(tile.tileset), palette)
                         graphic.hasRendered = True
                         
                     painter.drawPixmap(QPoint(x*32, y*32), graphic.rendered)
@@ -1665,7 +1668,8 @@ class MapEditorScene(QGraphicsScene):
                 sector.tileset, sector.palettegroup, sector.palette, 0)
             
             if not tilegraphic.hasRendered:
-                tilegraphic.render(self.projectData.getTileset(sector.tileset))
+                palette = self.projectData.getPaletteGroup(sector.palettegroup).palettes[sector.palette]
+                tilegraphic.render(self.projectData.getTileset(sector.tileset), palette)
                 
             # get the rects of each sector that matches the current one
             rects = []

--- a/src/mapeditor/map/map_scene.py
+++ b/src/mapeditor/map/map_scene.py
@@ -1501,20 +1501,31 @@ class MapEditorScene(QGraphicsScene):
         presetColours: dict[int, int] = {}
         for _, value, colour in json.loads(presets):
             presetColours[value] = colour
+            
+        previewing = self.state.isPreviewingPalette()
         
         for y in range(y0, y1+1):
             for x in range(x0, x1+1):
                 coords = EBCoords.fromTile(x, y)
                 try:
                     tile = self.projectData.getTile(coords)
-                    graphic = self.projectData.getTileGraphic(tile.tileset,
-                                                            tile.palettegroup,
-                                                            tile.palette,
-                                                            tile.tile)
-                    if not graphic.hasRendered:
-                        palette = self.projectData.getPaletteGroup(tile.palettegroup).palettes[tile.palette]
-                        graphic.render(self.projectData.getTileset(tile.tileset), palette)
-                        graphic.hasRendered = True
+                    if not previewing:
+                        graphic = self.projectData.getTileGraphic(tile.tileset,
+                                                                tile.palettegroup,
+                                                                tile.palette,
+                                                                tile.tile)
+                        if not graphic.hasRendered:
+                            palette = self.projectData.getPaletteGroup(tile.palettegroup).palettes[tile.palette]
+                            graphic.render(self.projectData.getTileset(tile.tileset), palette)
+                    else:
+                        graphic = self.projectData.getTileGraphic(tile.tileset,
+                                                                  self.state.previewingPaletteGroup,
+                                                                  self.state.previewingPalette,
+                                                                  tile.tile)
+                        if not graphic.hasRendered:
+                            palette = self.projectData.getPaletteGroup(
+                                self.state.previewingPaletteGroup).palettes[self.state.previewingPalette]
+                            graphic.render(self.projectData.getTileset(tile.tileset), palette)
                         
                     painter.drawPixmap(QPoint(x*32, y*32), graphic.rendered)
                     

--- a/src/misc/common.py
+++ b/src/misc/common.py
@@ -307,6 +307,15 @@ def normaliseFileExtension(path: str, ext: str) -> str:
         path += "." + ext
     return path
 
+def combinePaletteAndGroup(group: int, palette: int) -> str:
+    return f"{group}/{palette}"
+def extractPaletteAndGroup(combined: str) -> tuple[int, int]:
+    split = combined.split("/")
+    if len(split) != 2:
+        raise ValueError(f"Invalid palette group + palette string combination: {combined}")
+    
+    return int(split[0]), int(split[1])
+
 def showErrorMsg(title: str="Error", text: str="Error.", info: str=None,
                  icon: QMessageBox.Icon=QMessageBox.Icon.Critical):
     """Uniform error message box handling

--- a/src/misc/scratch.py
+++ b/src/misc/scratch.py
@@ -191,8 +191,8 @@ class TileScratchScene(QGraphicsScene):
                                                               palette,
                                                               tileID)
                     if not tileGfx.hasRendered:
-                        tileGfx.render(self.projectData.getTileset(tileset))
-                        tileGfx.hasRendered = True
+                        renderpalette = self.projectData.getPaletteGroup(palettegroup).palettes[palette]
+                        tileGfx.render(self.projectData.getTileset(tileset), renderpalette)
                             
                     painter.drawPixmap(x*32, y*32, tileGfx.rendered)
                         

--- a/src/objects/npc.py
+++ b/src/objects/npc.py
@@ -285,15 +285,29 @@ class MapEditorNPC(QGraphicsPixmapItem):
                 else:
                     brush = None
                         
+                previewing = self.scene().state.isPreviewingPalette()
                 for tile in tiles:
-                    graphic = self.scene().projectData.getTileGraphic(tile.tileset,
-                                                                    tile.palettegroup,
-                                                                    tile.palette,
-                                                                    tile.tile)
-                    
-                    if not graphic.hasRenderedFg:
-                        palette = self.scene().projectData.getPaletteGroup(tile.palettegroup).palettes[tile.palette]
-                        graphic.renderFg(self.scene().projectData.getTileset(tile.tileset), palette)
+                    if not previewing:
+                        graphic = self.scene().projectData.getTileGraphic(tile.tileset,
+                                                                        tile.palettegroup,
+                                                                        tile.palette,
+                                                                        tile.tile)
+                        
+                        if not graphic.hasRenderedFg:
+                                palette = self.scene().projectData.getPaletteGroup(tile.palettegroup).palettes[tile.palette]
+                                graphic.renderFg(self.scene().projectData.getTileset(tile.tileset), palette)
+                    else:
+                        graphic = self.scene().projectData.getTileGraphic(
+                            tile.tileset,
+                            self.scene().state.previewingPaletteGroup,
+                            self.scene().state.previewingPalette,
+                            tile.tile)
+                        
+                        if not graphic.hasRenderedFg:
+                            palette = self.scene().projectData.getPaletteGroup(
+                                self.scene().state.previewingPaletteGroup
+                            ).palettes[self.scene().state.previewingPalette]
+                            graphic.renderFg(self.scene().projectData.getTileset(tile.tileset), palette)
                     
                     target = (tile.coords.x - math.ceil(topLeft.x()) + self.offset().x(),
                             tile.coords.y - math.ceil(topLeft.y()) + self.offset().y())

--- a/src/objects/npc.py
+++ b/src/objects/npc.py
@@ -292,7 +292,8 @@ class MapEditorNPC(QGraphicsPixmapItem):
                                                                     tile.tile)
                     
                     if not graphic.hasRenderedFg:
-                        graphic.renderFg(self.scene().projectData.getTileset(tile.tileset))
+                        palette = self.scene().projectData.getPaletteGroup(tile.palettegroup).palettes[tile.palette]
+                        graphic.renderFg(self.scene().projectData.getTileset(tile.tileset), palette)
                     
                     target = (tile.coords.x - math.ceil(topLeft.x()) + self.offset().x(),
                             tile.coords.y - math.ceil(topLeft.y()) + self.offset().y())

--- a/src/objects/tile.py
+++ b/src/objects/tile.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (QGraphicsItem, QGraphicsPixmapItem,
                                QGraphicsRectItem, QGraphicsSimpleTextItem)
 
 import src.misc.common as common
-from src.coilsnake.fts_interpreter import FullTileset
+from src.coilsnake.fts_interpreter import FullTileset, Palette
 from src.misc.coords import EBCoords
 
 WHITEBRUSH = QBrush(Qt.white)
@@ -35,14 +35,12 @@ class MapTileGraphic:
         self.rendered: QPixmap = None
         self.renderedFg: QPixmap = None
     
-    def render(self, tileset: FullTileset): 
+    def render(self, tileset: FullTileset, palette: Palette): 
         """Create the image of this tile graphic and save it to this instance. Also sets `hasRendered` to True"""
-        palette = tileset.getPalette(self.palettegroup, self.palette)
         self.rendered = QPixmap.fromImage(ImageQt.ImageQt(tileset.tiles[self.tile].toImage(palette, tileset)))
         self.hasRendered = True
     
-    def renderFg(self, tileset: FullTileset):
+    def renderFg(self, tileset: FullTileset, palette: Palette):
         """Create the foreground image of this tile graphic and save it to this instance. Also sets `hasRenderedFg` to True"""
-        palette = tileset.getPalette(self.palettegroup, self.palette)
         self.renderedFg = QPixmap.fromImage(ImageQt.ImageQt(tileset.tiles[self.tile].toImage(palette, tileset, fgOnly=True)))
         self.hasRenderedFg = True

--- a/src/widgets/tile.py
+++ b/src/widgets/tile.py
@@ -361,8 +361,8 @@ class TilesetDisplayGraphicsScene(QGraphicsScene):
                                                                 self.currentPalette,
                                                                 tileID)
                         if not tileGfx.hasRendered:
-                            tileGfx.render(tileset)
-                            tileGfx.hasRendered = True
+                            palette = self.projectData.getPaletteGroup(tileGfx.palettegroup).palettes[tileGfx.palette]
+                            tileGfx.render(tileset, palette)
                             
                         painter.drawPixmap(x*32, y*32, tileGfx.rendered)
                         


### PR DESCRIPTION
This reworks the `tileGFX` cache to accommodate any palette used on any tileset. This allows the map to preview combinations that can be achieved by `fade_map_palette` / `[1F E1 ...]` in-game. A tool has been added to the Map Editor to see this.

Because the cache can now be much larger at its maximum, `MapTileGraphic`s are now created on-demand instead of during the project load.