### PR TITLE
Fix builds & add Python override + extra args to png2fts

### DIFF
--- a/ebme.spec.TEMPLATE
+++ b/ebme.spec.TEMPLATE
@@ -37,6 +37,7 @@ wheel_shiboken =
 plugins = platforms_qtforandroid
 
 [nuitka]
+mode = onefile
 # (str) specify any extra nuitka arguments
 # eg = extra_args = --show-modules --follow-stdlib
 extra_args = --windows-console-mode=disable --quiet --noinclude-qt-translations  --include-data-dir=./assets/fonts=assets/fonts --include-data-dir=./assets/gnat/fonts=assets/gnat/fonts --include-data-dir=./assets/gnat/animations=assets/gnat/animations --include-data-dir=./assets/gnat/levels=assets/gnat/levels --include-data-dir=./assets/gnat/sound/sfx=assets/gnat/sound/sfx --include-data-dir=./assets/gnat/sound/bgm=assets/gnat/sound/bgm --include-data-file=./assets/gnat/sound/sound.json=assets/gnat/sound/sound.json --include-data-file=./eb-png2fts/eb_png2fts.py=eb-png2fts/eb_png2fts.py --include-data-file=./eb-png2fts/image_cropper.py=eb-png2fts/image_cropper.py --include-data-file=./eb-png2fts/palettepacker.py=eb-png2fts/palettepacker.py --include-data-file=./eb-png2fts/LICENSE=eb-png2fts/LICENSE --windows-icon-from-ico=./assets/logos/icon.ico --static-libpython=no --assume-yes-for-downloads

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numpy == 2.1.2
 pillow == 11.0.0
 pyside6 == 6.8.0.2
 pyyaml == 6.0.2
-qtawesome == 1.3.1
-pygame # for ???
-requests # for update checking
+qtawesome == 1.3.1 # Version is important..?
+pygame == 2.6.1 # for gnat attack
+requests == 2.32.3 # for update checking. Version is important; nuitka bug prevents upgrading this and numpy bugs prevent upgrading nuitka

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy == 2.1.2
 pillow == 11.0.0
 pyside6 == 6.8.0.2
 pyyaml == 6.0.2
-qtawesome == 1.3.1 # Version is important..?
+qtawesome == 1.3.1
 pygame == 2.6.1 # for gnat attack
-requests == 2.32.3 # for update checking. Version is important; nuitka bug prevents upgrading this and numpy bugs prevent upgrading nuitka
+requests == 2.32.3 # for update checking
+certifi == 2025.4.26 # dependency of requests, however, a later version has a bug with nuitka, so we must specify this version.

--- a/src/png2fts/ebme_png2fts.py
+++ b/src/png2fts/ebme_png2fts.py
@@ -1,4 +1,3 @@
-import sys
 import traceback
 
 from PySide6.QtCore import (QObject, QProcess, QSettings, QTemporaryFile,
@@ -32,7 +31,7 @@ class EBME_png2fts(QObject):
         if pythonOverride is not None and pythonOverride != "":
             self.png2ftsProcess.setProgram(pythonOverride)
         else:
-            self.png2ftsProcess.setProgram(sys.executable)
+            self.png2ftsProcess.setProgram("python")
         
         self.convertedTileset: FullTileset|None = None
 

--- a/src/png2fts/ebme_png2fts.py
+++ b/src/png2fts/ebme_png2fts.py
@@ -1,3 +1,4 @@
+import sys
 import traceback
 
 from PySide6.QtCore import (QObject, QProcess, QSettings, QTemporaryFile,
@@ -15,7 +16,7 @@ class EBME_png2fts(QObject):
     succeeded = Signal()
     newOutput = Signal(str)
     
-    def convert(self, projectData: ProjectData, pngPath: str, tilesetNumber: int, extraArgs: str=None):
+    def convert(self, projectData: ProjectData, pngPath: str, tilesetNumber: int, pythonOverride: str=None, extraArgs: str=None):
         self.temporaryMapFile = QTemporaryFile()
         self.temporaryMapFile.open()
 
@@ -27,7 +28,11 @@ class EBME_png2fts(QObject):
 
         self.png2ftsThread = QThread()
         self.png2ftsProcess = QProcess()
-        self.png2ftsProcess.setProgram("python") # TODO double-check if it's possible to use the bundled Python (it may not be?)
+        
+        if pythonOverride is not None and pythonOverride != "":
+            self.png2ftsProcess.setProgram(pythonOverride)
+        else:
+            self.png2ftsProcess.setProgram(sys.executable)
         
         self.convertedTileset: FullTileset|None = None
 
@@ -43,7 +48,7 @@ class EBME_png2fts(QObject):
                     '-m', self.temporaryMapFile.fileName()
                     ])
         
-        if (cleanExtraArgs := extraArgs.strip()) != "":
+        if extraArgs is not None and (cleanExtraArgs := extraArgs.strip()) != "":
             args.extend(cleanExtraArgs.split())
             
         args.extend([pngPath])

--- a/src/png2fts/png2fts_gui.py
+++ b/src/png2fts/png2fts_gui.py
@@ -9,6 +9,7 @@ from src.coilsnake.fts_interpreter import FullTileset
 from src.coilsnake.project_data import ProjectData
 from src.misc.dialogues import png2ftsLicenseDialog
 from src.png2fts.ebme_png2fts import EBME_png2fts
+from src.widgets.layout import HSeparator
 
 
 class png2ftsMapEditorGui(QDialog):
@@ -65,6 +66,7 @@ class png2ftsMapEditorGui(QDialog):
         self.png2fts.convert(self.projectData, 
                              self.pngInput.text(),
                              int(self.tilesetNumber.text()),
+                             self.pythonOverride.text(),
                              self.extraArgs.text())
 
     def onSuccess(self):
@@ -84,8 +86,6 @@ class png2ftsMapEditorGui(QDialog):
         self.cancelButton.setEnabled(True)
 
     def setupUI(self):
-        self.disclaimer = QLabel("png2fts support is still somewhat experimental.\nUse at your own risk!\nYou need Python installed on your system to use png2fts.")
-
         self.pngInputLayout = QHBoxLayout()
         self.pngInput = QLineEdit()
         self.pngInput.setPlaceholderText("Path to PNG file")
@@ -96,6 +96,10 @@ class png2ftsMapEditorGui(QDialog):
 
         self.tilesetNumber = QSpinBox()
         self.tilesetNumber.setRange(0, len(self.projectData.tilesets)-1)
+        
+        self.pythonOverride = QLineEdit()
+        self.pythonOverride.setPlaceholderText("(Use sys.executable)")
+        self.pythonOverride.setToolTip("Provide a path to a Python interpreter.\nYou only need to use this if you know why you're doing it.")
         
         self.extraArgs = QLineEdit()
         self.extraArgs.setPlaceholderText("(None)")
@@ -129,9 +133,10 @@ class png2ftsMapEditorGui(QDialog):
 
         layout = QVBoxLayout()
         formLayout = QFormLayout()
-        formLayout.addRow(self.disclaimer)
         formLayout.addRow("Input file", self.pngInputLayout)
         formLayout.addRow("Tileset to replace", self.tilesetNumber)
+        formLayout.addRow(HSeparator())
+        formLayout.addRow("Python override", self.pythonOverride)
         formLayout.addRow("Extra command-line args", self.extraArgs)
         formLayout.addRow(self.goCancelLayout)
         formLayout.addRow(self.outputLabel)

--- a/src/png2fts/png2fts_gui.py
+++ b/src/png2fts/png2fts_gui.py
@@ -88,6 +88,8 @@ class png2ftsMapEditorGui(QDialog):
         self.cancelButton.setEnabled(True)
 
     def setupUI(self):
+        self.disclaimer = QLabel("png2fts support is still somewhat experimental.\nUse at your own risk!\nYou need Python and PIL installed on your system to use png2fts.")
+        
         self.pngInputLayout = QHBoxLayout()
         self.pngInput = QLineEdit()
         self.pngInput.setPlaceholderText("Path to PNG file")
@@ -135,6 +137,7 @@ class png2ftsMapEditorGui(QDialog):
 
         layout = QVBoxLayout()
         formLayout = QFormLayout()
+        formLayout.addRow(self.disclaimer)
         formLayout.addRow("Input file", self.pngInputLayout)
         formLayout.addRow("Tileset to replace", self.tilesetNumber)
         formLayout.addRow(HSeparator())

--- a/src/png2fts/png2fts_gui.py
+++ b/src/png2fts/png2fts_gui.py
@@ -57,6 +57,7 @@ class png2ftsMapEditorGui(QDialog):
         self.pngInput.setDisabled(True)
         self.pngBrowse.setDisabled(True)
         self.tilesetNumber.setDisabled(True)
+        self.pythonOverride.setDisabled(True)
         self.extraArgs.setDisabled(True)
         self.goButton.setDisabled(True)
         self.cancelButton.setDisabled(True)
@@ -81,6 +82,7 @@ class png2ftsMapEditorGui(QDialog):
         self.pngInput.setEnabled(True)
         self.pngBrowse.setEnabled(True)
         self.tilesetNumber.setEnabled(True)
+        self.pythonOverride.setEnabled(True)
         self.extraArgs.setEnabled(True)
         self.goButton.setEnabled(True)
         self.cancelButton.setEnabled(True)
@@ -98,7 +100,7 @@ class png2ftsMapEditorGui(QDialog):
         self.tilesetNumber.setRange(0, len(self.projectData.tilesets)-1)
         
         self.pythonOverride = QLineEdit()
-        self.pythonOverride.setPlaceholderText("(Use sys.executable)")
+        self.pythonOverride.setPlaceholderText("(Use `python`)")
         self.pythonOverride.setToolTip("Provide a path to a Python interpreter.\nYou only need to use this if you know why you're doing it.")
         
         self.extraArgs = QLineEdit()


### PR DESCRIPTION
I was experimenting with using the bundled Python version to run png2fts, but it did not work. As a part of testing the change, I needed to test the builds, and it turned out they broke some time ago and would not boot.

After much digging, this seems to be an issue with a newer version of `certifi`, a dependency of `requests`. As such, I have added an older working version of `certifi` to requirements.txt.

Additionally, fields were added to the png2fts GUI to specify a Python interpreter and add extra arguments to the command.